### PR TITLE
Enabling software rendering on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ on:
   # pom's -SNAPSHOT suffix to keep them visibly distinct from real releases.
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   # ── Native images, one per release platform ──────────────────────────
   native:
@@ -148,7 +145,6 @@ jobs:
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
           NOTARIZATION_TEAM_ID: ${{ secrets.NOTARIZATION_TEAM_ID }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           BINARY=$(find target/gluonfx -maxdepth 3 -type f -name 'DiskSpace' | head -n 1)
           if [ -z "$BINARY" ]; then echo "binary not found" >&2; exit 1; fi
           APP="target/DiskSpace.app"
@@ -198,6 +194,11 @@ jobs:
     if: github.event_name == 'push'
     needs: [ native ]
     runs-on: ubuntu-latest
+    # Only the release job needs write access (to create the GitHub Release and
+    # attach assets). The native job runs with the workflow's default read-only
+    # GITHUB_TOKEN — least privilege especially for manually dispatched runs.
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual trigger from the Actions tab. Same matrix runs (Linux + macOS + Windows
+  # native builds), artifacts are uploaded as workflow artifacts, but no GitHub
+  # Release is created and macOS signing/notarization is skipped. Use this to
+  # verify the release build end-to-end without publishing or burning notarization
+  # quota. Artifacts download from the workflow run page; version label keeps the
+  # pom's -SNAPSHOT suffix to keep them visibly distinct from real releases.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -54,9 +61,26 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
+      # Tag push: rewrite pom version to match the tag (e.g. v0.3.3 → 0.3.3) so
+      # downstream artifact names line up with the release. workflow_dispatch:
+      # leave the pom version untouched (e.g. 0.3.3-SNAPSHOT) so dispatched
+      # artifacts are visibly distinct from real release artifacts.
       - name: Set version from tag
+        if: github.event_name == 'push'
         shell: bash
         run: mvn -B versions:set -DnewVersion="${GITHUB_REF_NAME#v}" -DgenerateBackupPoms=false
+
+      # Single source of truth for the artifact-name version. Tag push strips the
+      # leading `v`; dispatch reads the (now possibly -SNAPSHOT) pom version.
+      - name: Compute artifact version
+        shell: bash
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          else
+            VER=$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)
+            echo "VERSION=${VER}" >> "$GITHUB_ENV"
+          fi
 
       # Workaround for gluonhq/substrate#1318: see scripts/ header for details.
       - name: Patch GraalVM static-libs layout (Linux)
@@ -66,11 +90,12 @@ jobs:
       - name: Native build
         run: mvn -B -Pnative gluonfx:build
 
-      - name: Rename binary (Linux / Windows)
-        if: runner.os != 'macOS'
+      # Rename for Linux / Windows on every trigger, and for macOS on dispatch
+      # (tag push has its own macOS step that signs + packages a DMG instead).
+      - name: Rename binary
+        if: runner.os != 'macOS' || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           SRC=$(find target/gluonfx -maxdepth 3 -type f -name '${{ matrix.exe }}' | head -n 1)
           if [ -z "$SRC" ]; then echo "binary not found" >&2; exit 1; fi
           if [ "${{ matrix.exe }}" = "DiskSpace.exe" ]; then
@@ -90,7 +115,7 @@ jobs:
       # § Signing Windows artifacts.
 
       - name: Import signing certificate (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && github.event_name == 'push'
         shell: bash
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -110,12 +135,12 @@ jobs:
             -k "$KEYCHAIN_PWD" "$KEYCHAIN_PATH"
 
       - name: List signing identities (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && github.event_name == 'push'
         shell: bash
         run: security find-identity -v -p codesigning "$RUNNER_TEMP/build.keychain"
 
       - name: Assemble, sign, notarize and package DMG (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && github.event_name == 'push'
         shell: bash
         env:
           MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
@@ -152,7 +177,7 @@ jobs:
           xcrun stapler staple "$DMG"
 
       - name: Clean up keychain (macOS)
-        if: runner.os == 'macOS' && always()
+        if: runner.os == 'macOS' && github.event_name == 'push' && always()
         shell: bash
         run: security delete-keychain "$RUNNER_TEMP/build.keychain"
 
@@ -166,7 +191,11 @@ jobs:
             target/diskspace-*-${{ matrix.suffix }}.dmg
 
   # ── Create GitHub release with all artifacts ─────────────────────────
+  # Only fires on tag push. workflow_dispatch stops at the per-platform
+  # upload-artifact step above, so dispatched runs leave no GitHub Release
+  # and no published assets — only workflow artifacts on the run page.
   release:
+    if: github.event_name == 'push'
     needs: [ native ]
     runs-on: ubuntu-latest
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -325,15 +325,35 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </profile>
 
         <!--
-          Linux-auto-activated. Same `-lmanagement_ext` story as native-mac: with
-          `enable-monitoring=jfr` on in the `native` profile, JFR pulls in
-          com.sun.management.OperatingSystemImpl whose JNI methods live in
-          libmanagement_ext.a, and Substrate's default Linux link line doesn't include
-          it. Without this entry the link step fails with
-            "undefined reference to `Java_com_sun_management_internal_OperatingSystemImpl_initialize0'"
-          on the Linux CI runner. The .a lives in $GRAALVM_HOME/lib/static/linux-amd64/
-          (or linux-aarch64/ when we ship that flavour) and Substrate's -L search path
-          already covers that directory, so the bare -l is enough.
+          Linux-auto-activated. Two things going on here:
+
+          1. `enableSWRendering=true` — fixes "no suitable pipeline found" at startup on
+             Linux hosts where the ES2 pipeline fails its hardware-qualifier check (common:
+             llvmpipe / software Mesa, NVIDIA proprietary on Wayland sessions, headless
+             servers, VMs without GPU passthrough). Default Substrate Linux builds only
+             register the ES2 prism classes for reflection and only link `libprism_es2.a`;
+             when ES2 hits "Failed Graphics Hardware Qualifier check" the QuantumRenderer
+             fallback path tries `Class.forName("com.sun.prism.sw.SWPipeline")` and dies
+             with ClassNotFoundException because Substrate dead-stripped the SW classes.
+             Flipping this on tells gluonfx to (a) pull in Substrate's bundled
+             `reflectionconfig-javafxsw.json` + `jniconfig-javafxsw.json` (so SWPipeline,
+             SWResourceFactory, and the SSE/JSW effect peers survive the analysis) and
+             (b) add `-lprism_sw` to the link line so libprism_sw.a is statically linked.
+             Result: ES2 still tried first; if it fails, the SW pipeline now actually
+             initializes instead of bailing. Net binary-size cost is ~1-2 MB.
+
+             Not enabled on macOS (uses Metal — ES2 path never taken) or Windows (uses
+             D3D — ES2 fallback already covers most failures, and SW was never the
+             reported failure mode there).
+
+          2. `-lmanagement_ext`: with `enable-monitoring=jfr` on in the `native` profile,
+             JFR pulls in com.sun.management.OperatingSystemImpl whose JNI methods live
+             in libmanagement_ext.a, and Substrate's default Linux link line doesn't
+             include it. Without this entry the link step fails with
+               "undefined reference to `Java_com_sun_management_internal_OperatingSystemImpl_initialize0'"
+             on the Linux CI runner. The .a lives in $GRAALVM_HOME/lib/static/linux-amd64/
+             (or linux-aarch64/ when we ship that flavour) and Substrate's -L search path
+             already covers that directory, so the bare -l is enough.
         -->
         <profile>
             <id>native-linux</id>
@@ -350,6 +370,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                         <artifactId>gluonfx-maven-plugin</artifactId>
                         <version>${gluonfx-maven-plugin.version}</version>
                         <configuration>
+                            <enableSWRendering>true</enableSWRendering>
                             <linkerArgs>
                                 <arg>-lmanagement_ext</arg>
                             </linkerArgs>


### PR DESCRIPTION
Seems it will not be available unless explicitly enabled. This fix will enable it, which would hopefully make it work on platforms where hardware acceleration doesn't seem to work properly.

Also, making it possible to build through the release workflow without having to trigger a release by pushing a new tag. Should make it easier to verify that the binaries work before cutting the release.